### PR TITLE
Clarify room setup for HipChat users

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Lita.configure do |config|
 end
 ```
 
+**Note**: For HipChat, the room should be the JID of the HipChat room (eg. `123_development@conf.hipchat.com`)
+
 ## Usage
 
 You will need to add a GitHub Webhook url that points to: `http://address.of.lita/github-commits`


### PR DESCRIPTION
It's non-intuitive, but you can't put the room name as the value for the room, you need to find the HipChat JID of the specific room and use that as the value of the repo.

I ran into this issue today when trying to setup this plugin with our HipChat setup, which prompted me to go down a rabbit hole debugging the handler itself, when all along the issue was the name of the room. I hope this helps others using HipChat.
