### PR TITLE
Add branch to notification

### DIFF
--- a/lib/lita/handlers/github_commits.rb
+++ b/lib/lita/handlers/github_commits.rb
@@ -45,9 +45,10 @@ module Lita
 
       def format_message(payload)
         commits = payload['commits']
+        branch = branch_from_ref(payload['ref'])
         if commits.size > 0
           commit_pluralization = commits.size > 1 ? 'commits' : 'commit'
-          "[GitHub] Got #{commits.size} new #{commit_pluralization} from #{commits.first['author']['name']} on #{payload['repository']['owner']['name']}/#{payload['repository']['name']}"
+          "[GitHub] Got #{commits.size} new #{commit_pluralization} from #{commits.first['author']['name']} on #{payload['repository']['owner']['name']}/#{payload['repository']['name']} on the #{branch} branch"
         elsif payload['created']
           "[GitHub] #{payload['pusher']['name']} created: #{payload['ref']}: #{payload['base_ref']}"
         elsif payload['deleted']
@@ -56,6 +57,10 @@ module Lita
       rescue
         Lita.logger.warn "Error formatting message for #{repo} repo. Payload: #{payload}"
         return
+      end
+
+      def branch_from_ref(ref)
+        ref.split('/').last
       end
 
       def rooms_for_repo(repo)

--- a/spec/lita/handlers/github_commits_spec.rb
+++ b/spec/lita/handlers/github_commits_spec.rb
@@ -30,7 +30,7 @@ describe Lita::Handlers::GithubCommits, lita_handler: true do
         expect(robot).to receive(:send_message) do |target, message|
           expect(target.room).to eq("#baz")
           expect(message).to eq(
-            "[GitHub] Got 3 new commits from Garen Torikian on octokitty/testing")
+            "[GitHub] Got 3 new commits from Garen Torikian on octokitty/testing on the master branch")
         end
         subject.receive(request, response)
       end
@@ -47,7 +47,7 @@ describe Lita::Handlers::GithubCommits, lita_handler: true do
         expect(robot).to receive(:send_message) do |target, message|
           expect(target.room).to eq("#baz")
           expect(message).to eq(
-            "[GitHub] Got 1 new commit from Garen Torikian on octokitty/testing")
+            "[GitHub] Got 1 new commit from Garen Torikian on octokitty/testing on the master branch")
         end
         subject.receive(request, response)
       end


### PR DESCRIPTION
We have a lot of activity on various branches and it's hard to tell who's working on what. By outputting which branch is being worked, the team will get better insight into what's happening.
