### PR TITLE
Display commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ end
 
 **Note**: For HipChat, the room should be the JID of the HipChat room (eg. `123_development@conf.hipchat.com`)
 
+The output from Lita would look something like:
+
+```
+[GitHub] Got 3 new commits from Garen Torikian on octokitty/testing on the master branch
+  * Test
+  * This is me testing the windows client.
+  * Rename madame-bovary.txt to words/madame-bovary.txt
+```
+
 ## Usage
 
 You will need to add a GitHub Webhook url that points to: `http://address.of.lita/github-commits`

--- a/lib/lita/handlers/github_commits.rb
+++ b/lib/lita/handlers/github_commits.rb
@@ -48,8 +48,9 @@ module Lita
         branch = branch_from_ref(payload['ref'])
         if commits.size > 0
           author = committer_and_author(commits.first)
+          messages = commit_messages(commits)
           commit_pluralization = commits.size > 1 ? 'commits' : 'commit'
-          "[GitHub] Got #{commits.size} new #{commit_pluralization} #{author} on #{payload['repository']['owner']['name']}/#{payload['repository']['name']} on the #{branch} branch"
+          "[GitHub] Got #{commits.size} new #{commit_pluralization} #{author} on #{payload['repository']['owner']['name']}/#{payload['repository']['name']} on the #{branch} branch\n" + messages.join("\n")
         elsif payload['created']
           "[GitHub] #{payload['pusher']['name']} created: #{payload['ref']}: #{payload['base_ref']}"
         elsif payload['deleted']
@@ -70,6 +71,12 @@ module Lita
             "#{commit['committer']['name']}"
         else
           "from #{commit['author']['name']}"
+        end
+      end
+
+      def commit_messages(commits)
+        commits.collect do |commit|
+          "  * #{commit['message']}"
         end
       end
 

--- a/spec/lita/handlers/github_commits_spec.rb
+++ b/spec/lita/handlers/github_commits_spec.rb
@@ -29,8 +29,13 @@ describe Lita::Handlers::GithubCommits, lita_handler: true do
       it "sends a notification message to the applicable rooms" do
         expect(robot).to receive(:send_message) do |target, message|
           expect(target.room).to eq("#baz")
-          expect(message).to eq(
-            "[GitHub] Got 3 new commits from Garen Torikian on octokitty/testing on the master branch")
+          expect(message).to eq(<<-RESPONSE.chomp
+[GitHub] Got 3 new commits from Garen Torikian on octokitty/testing on the master branch
+  * Test
+  * This is me testing the windows client.
+  * Rename madame-bovary.txt to words/madame-bovary.txt
+                                RESPONSE
+                               )
         end
         subject.receive(request, response)
       end
@@ -46,8 +51,11 @@ describe Lita::Handlers::GithubCommits, lita_handler: true do
       it "sends a singular commit notification message to the applicable rooms" do
         expect(robot).to receive(:send_message) do |target, message|
           expect(target.room).to eq("#baz")
-          expect(message).to eq(
-            "[GitHub] Got 1 new commit from Garen Torikian on octokitty/testing on the master branch")
+          expect(message).to eq(<<-RESPONSE.chomp
+[GitHub] Got 1 new commit from Garen Torikian on octokitty/testing on the master branch
+  * Test
+                                RESPONSE
+                               )
         end
         subject.receive(request, response)
       end
@@ -61,9 +69,13 @@ describe Lita::Handlers::GithubCommits, lita_handler: true do
 
       it "sends a notification message to the applicable rooms" do
         expect(robot).to receive(:send_message) do |target, message|
-          expect(message).to eq(
-            "[GitHub] Got 3 new commits authored by Garen Torikian and " +
-            "committed by Repository Owner on octokitty/testing on the master branch")
+          expect(message).to eq(<<-RESPONSE.chomp
+[GitHub] Got 3 new commits authored by Garen Torikian and committed by Repository Owner on octokitty/testing on the master branch
+  * Test
+  * This is me testing the windows client.
+  * Rename madame-bovary.txt to words/madame-bovary.txt
+                                RESPONSE
+                               )
         end
         subject.receive(request, response)
       end


### PR DESCRIPTION
This PR adds commit messages to the output, this gives some context as to what each push is about, hopefully spurring some discussion from team mates.